### PR TITLE
Make Brq_signature data key case-insensitive.

### DIFF
--- a/src/Omnipay/Buckaroo/Message/AbstractRequest.php
+++ b/src/Omnipay/Buckaroo/Message/AbstractRequest.php
@@ -48,11 +48,13 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
 
     public function generateSignature($data)
     {
-        unset($data['Brq_signature']);
         uksort($data, 'strcasecmp');
 
         $str = '';
         foreach ($data as $key => $value) {
+            if (strcasecmp($key, 'Brq_signature') === 0) {
+                continue;
+            }
             $str .= $key.'='.$value;
         }
 

--- a/src/Omnipay/Buckaroo/Message/CompletePurchaseRequest.php
+++ b/src/Omnipay/Buckaroo/Message/CompletePurchaseRequest.php
@@ -15,7 +15,10 @@ class CompletePurchaseRequest extends AbstractRequest
 
         $data = $this->httpRequest->request->all();
 
-        if (strtolower($this->httpRequest->request->get('Brq_signature')) !== $this->generateSignature($data)) {
+        $upperCaseKeysData = array_change_key_case($data, CASE_UPPER);
+        $signature = strtolower($upperCaseKeysData['BRQ_SIGNATURE']);
+
+        if ($signature !== $this->generateSignature($data)) {
             throw new InvalidRequestException('Incorrect signature');
         }
 

--- a/src/Omnipay/Buckaroo/Message/CompletePurchaseResponse.php
+++ b/src/Omnipay/Buckaroo/Message/CompletePurchaseResponse.php
@@ -3,6 +3,7 @@
 namespace Omnipay\Buckaroo\Message;
 
 use Omnipay\Common\Message\AbstractResponse;
+use Omnipay\Common\Message\RequestInterface;
 
 /**
  * Buckaroo Complete Purchase Response
@@ -11,6 +12,11 @@ class CompletePurchaseResponse extends AbstractResponse
 {
     const SUCCESS = '190';
 
+    public function __construct(RequestInterface $request, $data)
+    {
+        parent::__construct($request, array_change_key_case($data, CASE_UPPER));
+    }
+
     public function isSuccessful()
     {
         return static::SUCCESS === $this->getCode();
@@ -18,22 +24,22 @@ class CompletePurchaseResponse extends AbstractResponse
 
     public function getCode()
     {
-        if (isset($this->data['Brq_statuscode'])) {
-            return $this->data['Brq_statuscode'];
+        if (isset($this->data['BRQ_STATUSCODE'])) {
+            return $this->data['BRQ_STATUSCODE'];
         }
     }
 
     public function getMessage()
     {
-        if (isset($this->data['Brq_statusmessage'])) {
-            return $this->data['Brq_statusmessage'];
+        if (isset($this->data['BRQ_STATUSMESSAGE'])) {
+            return $this->data['BRQ_STATUSMESSAGE'];
         }
     }
 
     public function getTransactionReference()
     {
-        if (isset($this->data['Brq_payment'])) {
-            return $this->data['Brq_payment'];
+        if (isset($this->data['BRQ_PAYMENT'])) {
+            return $this->data['BRQ_PAYMENT'];
         }
     }
 }

--- a/tests/Omnipay/Buckaroo/Message/AbstractRequestTest.php
+++ b/tests/Omnipay/Buckaroo/Message/AbstractRequestTest.php
@@ -56,6 +56,19 @@ class PurchaseRequestTest extends TestCase
         $this->assertSame($expected, $this->request->generateSignature($data));
     }
 
+    public function testGenerateSignatureCaseInsensitivity()
+    {
+        $this->request->setSecretKey('secret');
+        $data = array(
+            'Brq_websitekey' => 'a',
+            'Brq_amount' => 'b',
+            'BrQ_SIgnatURE' => 'ignore',
+        );
+
+        $expected = sha1('Brq_amount=bBrq_websitekey=asecret');
+        $this->assertSame($expected, $this->request->generateSignature($data));
+    }
+
     public function testSend()
     {
         $response = $this->request->send();

--- a/tests/Omnipay/Buckaroo/Message/CompletePurchaseRequestTest.php
+++ b/tests/Omnipay/Buckaroo/Message/CompletePurchaseRequestTest.php
@@ -28,6 +28,14 @@ class CompletePurchaseRequestTest extends TestCase
         $this->assertSame($this->getHttpRequest()->request->all(), $data);
     }
 
+    public function testGetDataSignatureKeyCaseInsensitivity()
+    {
+        $this->getHttpRequest()->request->set('Brq_SignATure', $this->request->generateSignature($this->getHttpRequest()->request->all()));
+        $data = $this->request->getData();
+
+        $this->assertSame($this->getHttpRequest()->request->all(), $data);
+    }
+
     /**
      * @expectedException Omnipay\Common\Exception\InvalidRequestException
      * @expectedExceptionMessage Incorrect signature

--- a/tests/Omnipay/Buckaroo/Message/CompletePurchaseResponseTest.php
+++ b/tests/Omnipay/Buckaroo/Message/CompletePurchaseResponseTest.php
@@ -22,6 +22,22 @@ class CompletePurchaseResponseTest extends TestCase
         $this->assertSame('5', $response->getTransactionReference());
     }
 
+    public function testKeyCaseInsensitivity()
+    {
+        $data = array(
+            'Brq_STATUSCODE' => '190',
+            'Brq_statusMESSAGE' => 'hi!',
+            'BRQ_payment' => '5',
+        );
+
+        $response = new CompletePurchaseResponse($this->getMockRequest(), $data);
+
+        $this->assertTrue($response->isSuccessful());
+        $this->assertSame('190', $response->getCode());
+        $this->assertSame('hi!', $response->getMessage());
+        $this->assertSame('5', $response->getTransactionReference());
+    }
+
     public function testEmpty()
     {
         $response = new CompletePurchaseResponse($this->getMockRequest(), array());


### PR DESCRIPTION
The key was included in signature calculation and comparison when its case was different than 'Brq_signature' as described in omnipay/buckaroo#3.

The tests do pass, but fail on Travis due to omnipay/tests#1.
