### PR TITLE
Add support for Mastercard and American express

### DIFF
--- a/src/BuckarooGateway.php
+++ b/src/BuckarooGateway.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Omnipay\Buckaroo;
+
+use Omnipay\Common\AbstractGateway;
+
+/**
+ * Buckaroo Credit Card Gateway
+ */
+class BuckarooGateway extends AbstractGateway
+{
+    public function getName()
+    {
+        return 'Buckaroo Gateway';
+    }
+
+    public function getDefaultParameters()
+    {
+        return array(
+            'websiteKey' => '',
+            'secretKey' => '',
+            'testMode' => false,
+        );
+    }
+
+    public function getWebsiteKey()
+    {
+        return $this->getParameter('websiteKey');
+    }
+
+    public function setWebsiteKey($value)
+    {
+        return $this->setParameter('websiteKey', $value);
+    }
+
+    public function getSecretKey()
+    {
+        return $this->getParameter('secretKey');
+    }
+
+    public function setSecretKey($value)
+    {
+        return $this->setParameter('secretKey', $value);
+    }
+
+    public function completePurchase(array $parameters = array())
+    {
+        return $this->createRequest('\Omnipay\Buckaroo\Message\CompletePurchaseRequest', $parameters);
+    }
+}

--- a/src/CreditCardGateway.php
+++ b/src/CreditCardGateway.php
@@ -7,49 +7,25 @@ use Omnipay\Common\AbstractGateway;
 /**
  * Buckaroo Credit Card Gateway
  */
-class CreditCardGateway extends AbstractGateway
+class CreditCardGateway extends BuckarooGateway
 {
     public function getName()
     {
         return 'Buckaroo Credit Card';
     }
 
-    public function getDefaultParameters()
+    public function getPaymentMethod($value)
     {
-        return array(
-            'websiteKey' => '',
-            'secretKey' => '',
-            'testMode' => false,
-        );
+        return $this->setParameter('paymentMethod', $value);
     }
 
-    public function getWebsiteKey()
+    public function setPaymentMethod()
     {
-        return $this->getParameter('websiteKey');
-    }
-
-    public function setWebsiteKey($value)
-    {
-        return $this->setParameter('websiteKey', $value);
-    }
-
-    public function getSecretKey()
-    {
-        return $this->getParameter('secretKey');
-    }
-
-    public function setSecretKey($value)
-    {
-        return $this->setParameter('secretKey', $value);
+        return $this->getParameter('paymentMethod');
     }
 
     public function purchase(array $parameters = array())
     {
         return $this->createRequest('\Omnipay\Buckaroo\Message\CreditCardPurchaseRequest', $parameters);
-    }
-
-    public function completePurchase(array $parameters = array())
-    {
-        return $this->createRequest('\Omnipay\Buckaroo\Message\CompletePurchaseRequest', $parameters);
     }
 }

--- a/src/IdealGateway.php
+++ b/src/IdealGateway.php
@@ -5,7 +5,7 @@ namespace Omnipay\Buckaroo;
 /**
  * Buckaroo iDeal Gateway
  */
-class IdealGateway extends CreditCardGateway
+class IdealGateway extends BuckarooGateway
 {
     public function getName()
     {

--- a/src/Message/CreditCardPurchaseRequest.php
+++ b/src/Message/CreditCardPurchaseRequest.php
@@ -10,7 +10,7 @@ class CreditCardPurchaseRequest extends AbstractRequest
     public function getData()
     {
         $data = parent::getData();
-        $data['Brq_payment_method'] = 'visa';
+        $data['Brq_payment_method'] = $this->getPaymentMethod();
 
         return $data;
     }

--- a/src/Message/CreditCardPurchaseRequest.php
+++ b/src/Message/CreditCardPurchaseRequest.php
@@ -10,7 +10,14 @@ class CreditCardPurchaseRequest extends AbstractRequest
     public function getData()
     {
         $data = parent::getData();
-        $data['Brq_payment_method'] = $this->getPaymentMethod();
+
+        $creditcardProviders = array('visa', 'mastercard', 'amex');
+
+        if (in_array($this->getPaymentMethod(), $creditcardProviders)) {
+            $data['Brq_payment_method'] = $this->getPaymentMethod();
+        } else {
+            $data['Brq_requestedservices'] = implode(",", $creditcardProviders);
+        }
 
         return $data;
     }

--- a/src/PayPalGateway.php
+++ b/src/PayPalGateway.php
@@ -5,7 +5,7 @@ namespace Omnipay\Buckaroo;
 /**
  * Buckaroo PayPal Gateway
  */
-class PayPalGateway extends CreditCardGateway
+class PayPalGateway extends BuckarooGateway
 {
     public function getName()
     {

--- a/tests/CreditCardGatewayTest.php
+++ b/tests/CreditCardGatewayTest.php
@@ -16,7 +16,6 @@ class CreditCardGatewayTest extends GatewayTestCase
     public function testPurchase()
     {
         $request = $this->gateway->purchase(array('amount' => '10.00'));
-
         $this->assertInstanceOf('Omnipay\Buckaroo\Message\CreditCardPurchaseRequest', $request);
         $this->assertSame('10.00', $request->getAmount());
     }

--- a/tests/Message/CreditCardPurchaseRequestTest.php
+++ b/tests/Message/CreditCardPurchaseRequestTest.php
@@ -45,5 +45,29 @@ class CreditCardPurchaseRequestTest extends TestCase
         $this->assertSame('nl-NL', $data['Brq_culture']);
         $this->assertSame('mastercard', $data['Brq_payment_method']);
     }
+    public function testGetDataPaymentMethodFallback()
+    {
+        $this->request->initialize(array(
+            'websiteKey' => 'web',
+            'secretKey' => 'secret',
+            'amount' => '12.00',
+            'currency' => 'EUR',
+            'testMode' => true,
+            'transactionId' => 13,
+            'returnUrl' => 'https://www.example.com/return',
+            'cancelUrl' => 'https://www.example.com/cancel',
+            'culture' => 'nl-NL',
+        ));
 
+        $data = $this->request->getData();
+
+        $this->assertSame('web', $data['Brq_websitekey']);
+        $this->assertSame('12.00', $data['Brq_amount']);
+        $this->assertSame('EUR', $data['Brq_currency']);
+        $this->assertSame(13, $data['Brq_invoicenumber']);
+        $this->assertSame('https://www.example.com/return', $data['Brq_return']);
+        $this->assertSame('https://www.example.com/cancel', $data['Brq_returncancel']);
+        $this->assertSame('nl-NL', $data['Brq_culture']);
+        $this->assertSame('visa,mastercard,amex', $data['Brq_requestedservices']);
+    }
 }

--- a/tests/Message/CreditCardPurchaseRequestTest.php
+++ b/tests/Message/CreditCardPurchaseRequestTest.php
@@ -21,8 +21,29 @@ class CreditCardPurchaseRequestTest extends TestCase
 
     public function testGetData()
     {
+        $this->request->initialize(array(
+            'websiteKey' => 'web',
+            'secretKey' => 'secret',
+            'amount' => '12.00',
+            'currency' => 'EUR',
+            'testMode' => true,
+            'transactionId' => 13,
+            'returnUrl' => 'https://www.example.com/return',
+            'cancelUrl' => 'https://www.example.com/cancel',
+            'culture' => 'nl-NL',
+            'paymentMethod' => 'mastercard'
+        ));
+
         $data = $this->request->getData();
 
-        $this->assertSame('visa', $data['Brq_payment_method']);
+        $this->assertSame('web', $data['Brq_websitekey']);
+        $this->assertSame('12.00', $data['Brq_amount']);
+        $this->assertSame('EUR', $data['Brq_currency']);
+        $this->assertSame(13, $data['Brq_invoicenumber']);
+        $this->assertSame('https://www.example.com/return', $data['Brq_return']);
+        $this->assertSame('https://www.example.com/cancel', $data['Brq_returncancel']);
+        $this->assertSame('nl-NL', $data['Brq_culture']);
+        $this->assertSame('mastercard', $data['Brq_payment_method']);
     }
+
 }


### PR DESCRIPTION
This PR will add the option to choose between 3 credit card providers. 

usage : 
`$request->setPaymentMethod('mastercard');`

or

`$gateway->purchase(['paymentMethod' => 'mastercard]');`

or 

`$gateway->setPaymentMethod('mastercard');`

supported methods: 
- Visa (visa )
- Mastercard ( mastercard )
- American express ( amex )

if none of the currently supported payment methods is selected, there will be a fallback to 

`Brq_setrequestedservices  = 'visa,mastercard,amex';`

which redirects the user to a page in buckaroo where they will select supported creditcard provider they wish.


to make sure this functionality is only available for credit card, i created the 
buckaroo gateway. (`src/BuckarooGateway.php`)

the Creditcard, Paypal, and iDeal gateways now extend  `BuckarooGateway` , instead of extending `CreditCardGateway`