### PR TITLE
Adds support for reject and error urls in requests

### DIFF
--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -40,6 +40,27 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
         return $this->setParameter('culture', $value);
     }
 
+    public function getRejectUrl()
+    {
+        return $this->getParameter('rejectUrl');
+    }
+
+    public function setRejectUrl($value)
+    {
+        return $this->setParameter('rejectUrl', $value);
+    }
+
+    public function getErrorUrl()
+    {
+        return $this->getParameter('errorUrl');
+    }
+
+    public function setErrorUrl($value)
+    {
+        return $this->setParameter('errorUrl', $value);
+    }
+
+
     public function getData()
     {
         $this->validate('websiteKey', 'secretKey', 'amount', 'returnUrl');
@@ -52,6 +73,8 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
         $data['Brq_description'] = $this->getDescription();
         $data['Brq_return'] = $this->getReturnUrl();
         $data['Brq_returncancel'] = $this->getCancelUrl();
+        $data['Brq_returnreject'] = $this->getRejectUrl();
+        $data['Brq_returnerror'] = $this->getErrorUrl();
         $data['Brq_culture'] = $this->getCulture();
 
         return $data;

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -40,21 +40,45 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
         return $this->setParameter('culture', $value);
     }
 
+    /**
+     * @return string url rejectUrl
+     */
     public function getRejectUrl()
     {
         return $this->getParameter('rejectUrl');
     }
 
+    /**
+     * sets the Reject URL which is used by buckaroo when
+     * the payment is rejected.
+     *
+     * @param $value
+     *
+     * @return \Omnipay\Common\Message\AbstractRequest
+     */
     public function setRejectUrl($value)
     {
         return $this->setParameter('rejectUrl', $value);
     }
 
+    /**
+     * returns the error URL
+     *
+     * @return string errorUrl
+     */
     public function getErrorUrl()
     {
         return $this->getParameter('errorUrl');
     }
 
+    /**
+     * sets the error URL which is used by buckaroo when
+     * the payment results in an error
+     *
+     * @param $value
+     *
+     * @return \Omnipay\Common\Message\AbstractRequest
+     */
     public function setErrorUrl($value)
     {
         return $this->setParameter('errorUrl', $value);

--- a/tests/Message/AbstractRequestTest.php
+++ b/tests/Message/AbstractRequestTest.php
@@ -31,6 +31,8 @@ class PurchaseRequestTest extends TestCase
             'transactionId' => 13,
             'returnUrl' => 'https://www.example.com/return',
             'cancelUrl' => 'https://www.example.com/cancel',
+            'errorUrl' => 'https://www.example.com/error',
+            'rejectUrl' => 'https://www.example.com/reject',
             'culture' => 'nl-NL',
         ));
 
@@ -42,6 +44,8 @@ class PurchaseRequestTest extends TestCase
         $this->assertSame(13, $data['Brq_invoicenumber']);
         $this->assertSame('https://www.example.com/return', $data['Brq_return']);
         $this->assertSame('https://www.example.com/cancel', $data['Brq_returncancel']);
+        $this->assertSame('https://www.example.com/error', $data['Brq_returnerror']);
+        $this->assertSame('https://www.example.com/reject', $data['Brq_returnreject']);
         $this->assertSame('nl-NL', $data['Brq_culture']);
     }
 


### PR DESCRIPTION
This will add support for bucakroo's `Brq_returnerror` and `Brq_returnreject` .

usage : 


`$request->setRejectUrl('http://example.com/reject');`

`$request->setErrorUrl('http://example.com/error');`
