### PR TITLE
Added support for iDeal issuer

### DIFF
--- a/src/BuckarooGateway.php
+++ b/src/BuckarooGateway.php
@@ -43,6 +43,11 @@ class BuckarooGateway extends AbstractGateway
         return $this->setParameter('secretKey', $value);
     }
 
+    public function purchase(array $parameters = array())
+    {
+        return $this->createRequest('\Omnipay\Buckaroo\Message\PurchaseRequest', $parameters);
+    }
+
     public function completePurchase(array $parameters = array())
     {
         return $this->createRequest('\Omnipay\Buckaroo\Message\CompletePurchaseRequest', $parameters);

--- a/src/Message/IdealPurchaseRequest.php
+++ b/src/Message/IdealPurchaseRequest.php
@@ -12,6 +12,10 @@ class IdealPurchaseRequest extends AbstractRequest
         $data = parent::getData();
         $data['Brq_payment_method'] = 'ideal';
 
+        if ($this->getIssuer()) {
+            $data['Brq_service_ideal_issuer'] = $this->getIssuer();
+        }
+
         return $data;
     }
 }

--- a/src/Message/PurchaseRequest.php
+++ b/src/Message/PurchaseRequest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Omnipay\Buckaroo\Message;
+
+/**
+ * Buckaroo Purchase Request.
+ *
+ * With this purchase request Buckaroo will show all payment options configured for the website (websiteKey).
+ * The user must choose the payment method on the Buckaroo page.
+ */
+class PurchaseRequest extends AbstractRequest
+{
+    public function getData()
+    {
+        $data = parent::getData();
+        unset($data['Brq_payment_method']);
+        unset($data['Brq_service_ideal_issuer']);
+        unset($data['Brq_requestedservices']);
+
+        return $data;
+    }
+}

--- a/tests/BuckarooGatewayTest.php
+++ b/tests/BuckarooGatewayTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Omnipay\Buckaroo;
+
+use Omnipay\Tests\GatewayTestCase;
+
+class BuckarooGatewayTest extends GatewayTestCase
+{
+    /**
+     * @var BuckarooGateway
+     */
+    protected $gateway;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->gateway = new BuckarooGateway($this->getHttpClient(), $this->getHttpRequest());
+    }
+
+    public function testPurchase()
+    {
+        $request = $this->gateway->purchase(array('amount' => '10.00'));
+
+        $this->assertInstanceOf('Omnipay\Buckaroo\Message\PurchaseRequest', $request);
+        $this->assertSame('10.00', $request->getAmount());
+    }
+}

--- a/tests/IdealGatewayTest.php
+++ b/tests/IdealGatewayTest.php
@@ -2,6 +2,7 @@
 
 namespace Omnipay\Buckaroo;
 
+use Omnipay\Buckaroo\Message\IdealPurchaseRequest;
 use Omnipay\Tests\GatewayTestCase;
 
 class IdealGatewayTest extends GatewayTestCase
@@ -9,7 +10,7 @@ class IdealGatewayTest extends GatewayTestCase
     public function setUp()
     {
         parent::setUp();
-
+        
         $this->gateway = new IdealGateway($this->getHttpClient(), $this->getHttpRequest());
     }
 
@@ -19,5 +20,30 @@ class IdealGatewayTest extends GatewayTestCase
 
         $this->assertInstanceOf('Omnipay\Buckaroo\Message\IdealPurchaseRequest', $request);
         $this->assertSame('10.00', $request->getAmount());
+    }
+
+    public function testIdealIssuerChosen()
+    {
+        /** @var IdealPurchaseRequest $request */
+        $request = $this->gateway->purchase(array(
+            'amount' => '10.00',
+            'returnUrl' => 'https://www.example.com/return',
+            'issuer' => 'TRIONL2U'
+        ));
+
+        $data = $request->getData();
+
+        $this->assertSame('TRIONL2U', $data['Brq_service_ideal_issuer']);
+    }
+
+    public function testIdealIssuerIsNotRequired()
+    {
+        /** @var IdealPurchaseRequest $request */
+        $request = $this->gateway->purchase(array(
+            'amount' => '10.00',
+            'returnUrl' => 'https://www.example.com/return',
+        ));
+
+        $this->assertNotContains('Brq_service_ideal_issuer', $request->getData());
     }
 }

--- a/tests/Message/AbstractRequestTest.php
+++ b/tests/Message/AbstractRequestTest.php
@@ -5,7 +5,7 @@ namespace Omnipay\Buckaroo\Message;
 use Mockery as m;
 use Omnipay\Tests\TestCase;
 
-class PurchaseRequestTest extends TestCase
+class AbstractRequestTest extends TestCase
 {
     public function setUp()
     {

--- a/tests/Message/PurchaseRequestTest.php
+++ b/tests/Message/PurchaseRequestTest.php
@@ -26,7 +26,29 @@ class PurchaseRequestTest extends TestCase
 
     public function testGetData()
     {
+        $this->request->initialize(array(
+            'websiteKey' => 'web',
+            'secretKey' => 'secret',
+            'amount' => '12.00',
+            'currency' => 'EUR',
+            'testMode' => true,
+            'transactionId' => 13,
+            'returnUrl' => 'https://www.example.com/return',
+            'cancelUrl' => 'https://www.example.com/cancel',
+            'culture' => 'nl-NL',
+            'paymentMethod' => 'mastercard',
+            'issuer' => 'RABONL2U',
+        ));
+
         $data = $this->request->getData();
+
+        $this->assertSame('web', $data['Brq_websitekey']);
+        $this->assertSame('12.00', $data['Brq_amount']);
+        $this->assertSame('EUR', $data['Brq_currency']);
+        $this->assertSame(13, $data['Brq_invoicenumber']);
+        $this->assertSame('https://www.example.com/return', $data['Brq_return']);
+        $this->assertSame('https://www.example.com/cancel', $data['Brq_returncancel']);
+        $this->assertSame('nl-NL', $data['Brq_culture']);
 
         $this->assertNotContains('Brq_payment_method', $data);
         $this->assertNotContains('Brq_service_ideal_issuer', $data);

--- a/tests/Message/PurchaseRequestTest.php
+++ b/tests/Message/PurchaseRequestTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Omnipay\Buckaroo\Message;
+
+use Omnipay\Tests\TestCase;
+
+class PurchaseRequestTest extends TestCase
+{
+    /**
+     * @var PurchaseRequest
+     */
+    protected $request;
+
+    public function setUp()
+    {
+        $this->request = new PurchaseRequest($this->getHttpClient(), $this->getHttpRequest());
+        $this->request->initialize(
+            array(
+                'websiteKey' => 'web',
+                'secretKey' => 'secret',
+                'amount' => '12.00',
+                'returnUrl' => 'https://www.example.com/return',
+            )
+        );
+    }
+
+    public function testGetData()
+    {
+        $data = $this->request->getData();
+
+        $this->assertNotContains('Brq_payment_method', $data);
+        $this->assertNotContains('Brq_service_ideal_issuer', $data);
+        $this->assertNotContains('Brq_requestedservices', $data);
+    }
+}


### PR DESCRIPTION
Support added for iDeal issuers. By setting the iDeal issuer on your website it's possible to skip a step on the Buckaroo payment page.