### PR TITLE
Added the iDEAL processing gateway

### DIFF
--- a/src/IdealProcessingGateway.php
+++ b/src/IdealProcessingGateway.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Omnipay\Buckaroo;
+
+/**
+ * Buckaroo iDeal Processing Gateway
+ */
+class IdealProcessingGateway extends BuckarooGateway
+{
+    public function getName()
+    {
+        return 'Buckaroo iDeal Processing';
+    }
+
+    public function purchase(array $parameters = array())
+    {
+        return $this->createRequest('\Omnipay\Buckaroo\Message\IdealProcessingPurchaseRequest', $parameters);
+    }
+}

--- a/src/Message/IdealProcessingPurchaseRequest.php
+++ b/src/Message/IdealProcessingPurchaseRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Omnipay\Buckaroo\Message;
+
+/**
+ * Buckaroo iDeal Processing Purchase Request
+ */
+class IdealProcessingPurchaseRequest extends AbstractRequest
+{
+    public function getData()
+    {
+        $data = parent::getData();
+        $data['Brq_payment_method'] = 'idealprocessing';
+
+        if ($this->getIssuer()) {
+            $data['Brq_service_idealprocessing_issuer'] = $this->getIssuer();
+        }
+
+        return $data;
+    }
+}

--- a/tests/IdealProcessingGatewayTest.php
+++ b/tests/IdealProcessingGatewayTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Omnipay\Buckaroo;
+
+use Omnipay\Buckaroo\Message\IdealProcessingPurchaseRequest;
+use Omnipay\Tests\GatewayTestCase;
+
+class IdealProcessingGatewayTest extends GatewayTestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+        
+        $this->gateway = new IdealProcessingGateway($this->getHttpClient(), $this->getHttpRequest());
+    }
+
+    public function testPurchase()
+    {
+        $request = $this->gateway->purchase(array('amount' => '10.00'));
+
+        $this->assertInstanceOf('Omnipay\Buckaroo\Message\IdealProcessingPurchaseRequest', $request);
+        $this->assertSame('10.00', $request->getAmount());
+    }
+
+    public function testIdealIssuerChosen()
+    {
+        /** @var IdealProcessingPurchaseRequest $request */
+        $request = $this->gateway->purchase(array(
+            'amount' => '10.00',
+            'returnUrl' => 'https://www.example.com/return',
+            'issuer' => 'TRIONL2U'
+        ));
+
+        $data = $request->getData();
+
+        $this->assertSame('TRIONL2U', $data['Brq_service_idealprocessing_issuer']);
+    }
+
+    public function testIdealIssuerIsNotRequired()
+    {
+        /** @var IdealProcessingPurchaseRequest $request */
+        $request = $this->gateway->purchase(array(
+            'amount' => '10.00',
+            'returnUrl' => 'https://www.example.com/return',
+        ));
+
+        $this->assertNotContains('Brq_service_idealprocessing_issuer', $request->getData());
+    }
+}

--- a/tests/Message/IdealProcessingPurchaseRequestTest.php
+++ b/tests/Message/IdealProcessingPurchaseRequestTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Omnipay\Buckaroo\Message;
+
+use Omnipay\Tests\TestCase;
+
+class IdealProcessingPurchaseRequestTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->request = new IdealProcessingPurchaseRequest($this->getHttpClient(), $this->getHttpRequest());
+        $this->request->initialize(
+            array(
+                'websiteKey' => 'web',
+                'secretKey' => 'secret',
+                'amount' => '12.00',
+                'returnUrl' => 'https://www.example.com/return',
+            )
+        );
+    }
+
+    public function testGetData()
+    {
+        $data = $this->request->getData();
+
+        $this->assertSame('idealprocessing', $data['Brq_payment_method']);
+    }
+}


### PR DESCRIPTION
Buckaroo allows you to hook up your external iDEAL contracts to your account and process payments via your own contracts. However, when doing so, you need to pass the `idealprocessing` payment method instead of the `ideal` method ([docs](https://dev.buckaroo.nl/PaymentMethods/Description/ideal)).

This PR implements an additional gateway specifically for iDEAL processing.