### PR TITLE
Remove unused parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.idea
 /vendor
 composer.lock
 composer.phar

--- a/src/Message/CompletePurchaseRequest.php
+++ b/src/Message/CompletePurchaseRequest.php
@@ -11,7 +11,7 @@ class CompletePurchaseRequest extends AbstractRequest
 {
     public function getData()
     {
-        $this->validate('websiteKey', 'secretKey', 'amount');
+        $this->validate('websiteKey', 'secretKey');
 
         $originalData = $this->httpRequest->request->all();
         $data = array_change_key_case($originalData, CASE_UPPER);


### PR DESCRIPTION
Remove unused amount parameter in CompletePurchaseRequest. Validation on this parameter means you have to access your order before you can actually access the PaymentId trough a gateway meaning you have to add custom logic for buckaroo payments. IE:

```php
$order = Order::find($request->get('BQ_INVOICENUMBER'));
$response = Omnipay::CompletePurchase(array_merge(
    [ 'amount' => $order->amount ],
    request()->all(),
))->send();
```

With this fix this is no longer required.